### PR TITLE
Listen on the window

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 chrome.storage.local.get('disabled', ({ disabled }) => {
   if (!disabled) {
-    document.addEventListener('pointerdown', (event) => {
+    window.addEventListener('pointerdown', (event) => {
       event.target.setPointerCapture(event.pointerId)
     }, true)
   }


### PR DESCRIPTION
May handle a few more cases correctly (since capturing window listeners are invoked before capturing document listeners).
