### PR TITLE
Only capture when the target is an Element

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,7 +1,8 @@
 chrome.storage.local.get('disabled', ({ disabled }) => {
   if (!disabled) {
     window.addEventListener('pointerdown', (event) => {
-      event.target.setPointerCapture(event.pointerId)
+      if (event.target instanceof Element)
+        event.target.setPointerCapture(event.pointerId)
     }, true)
   }
 })


### PR DESCRIPTION
In some situations the target of an event could possibly be a Document or a Window, which don't have a way (or a need really) to set pointer capture.  Just skip those cases, they should be effectively "captured" already.
